### PR TITLE
Added  MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2012, Niels Krijger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE

--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,8 @@
 Features
 ========
 
-A Symfony2 bundle featuring:  
-- Breadcrumbs service with a chained interface  
+A Symfony2 bundle featuring:
+- Breadcrumbs service with a chained interface
 - Twig integration
 
 Documentation
@@ -12,10 +12,8 @@ The documentation can be found in:
 
     Resources/doc/index.md
 
-License
+License: MIT
 -------
-
-Do whatever you like with this bundle.
 
 Reporting an issue or a feature request
 ---------------------------------------


### PR DESCRIPTION
Clear license is better for every developer.
MIT license is standard license in Symfony world.
